### PR TITLE
Add KeyHandler to RateLimitConfig

### DIFF
--- a/Example/Sources/main.swift
+++ b/Example/Sources/main.swift
@@ -3,6 +3,9 @@ import KituraRateLimit
 
 let router = Router()
 
+
+// MARK: - defaultConfig
+
 // Apply rate limiting with default configuration in "/" path
 router.get("/", allowPartialMatch: false, middleware: RateLimit(config: .defaultConfig, keyStore: MemoryCacheRateLimitKeyStore()))
 router.get("/") {
@@ -12,21 +15,51 @@ router.get("/") {
 
 }
 
+
+// MARK: - helloConfig
+
 // Custom rate limit configuration for "/hello"
 extension RateLimitConfig {
-    static var helloRouteConfig: RateLimitConfig {
+    static var helloConfig: RateLimitConfig {
         return RateLimitConfig(window: 100, maxRequests: 10, includeHeaders: true)
     }
 }
 
 // Apply rate limiting with custom configuratioon in "/hello"
-router.get("/hello", allowPartialMatch: false, middleware: RateLimit(config: .helloRouteConfig, keyStore: MemoryCacheRateLimitKeyStore()))
+router.get("/hello", allowPartialMatch: false, middleware: RateLimit(config: .helloConfig, keyStore: MemoryCacheRateLimitKeyStore()))
 router.get("/hello") {
     request, response, next in
 
     try response.status(.OK).send("Hello there!").end()
 
 }
+
+
+// MARK: - customKeyConfig
+
+// Custom rate limit configuration for "/hello"
+extension RateLimitConfig {
+    static var customKeyConfig: RateLimitConfig {
+        return RateLimitConfig(window: 10, maxRequests: 10, includeHeaders: true, handler: RateLimitConfig.defaultHandler, keyHandler: RateLimitConfig.customKeyHandler)
+    }
+    
+    public static var customKeyHandler: KeyHandler = {
+        request in
+        
+        return request.queryParameters["client_id"] ?? ""
+    }
+}
+
+// Apply rate limiting with custom configuratioon in "/hello"
+// Veryfy that `router.get("/customKey"…` request queryParameters has a valid client_id
+router.get("/customKey", allowPartialMatch: false, middleware: RateLimit(config: .customKeyConfig, keyStore: MemoryCacheRateLimitKeyStore()))
+router.get("/customKey") {
+    request, response, next in
+    
+    try response.status(.OK).send("Hello there!").end()
+    
+}
+
 
 Kitura.addHTTPServer(onPort: 3000, with: router)
 Kitura.run()

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ import KituraRateLimit
 
 let router = Router()
 
+
+// MARK: - defaultConfig
+
 // Apply rate limiting with default configuration in "/" path
 router.get("/", allowPartialMatch: false, middleware: RateLimit(config: .defaultConfig, keyStore: MemoryCacheRateLimitKeyStore()))
 router.get("/") {
@@ -34,21 +37,51 @@ router.get("/") {
 
 }
 
+
+// MARK: - helloConfig
+
 // Custom rate limit configuration for "/hello"
 extension RateLimitConfig {
-    static var helloRouteConfig: RateLimitConfig {
+    static var helloConfig: RateLimitConfig {
         return RateLimitConfig(window: 100, maxRequests: 10, includeHeaders: true)
     }
 }
 
 // Apply rate limiting with custom configuratioon in "/hello"
-router.get("/hello", allowPartialMatch: false, middleware: RateLimit(config: .helloRouteConfig, keyStore: MemoryCacheRateLimitKeyStore()))
+router.get("/hello", allowPartialMatch: false, middleware: RateLimit(config: .helloConfig, keyStore: MemoryCacheRateLimitKeyStore()))
 router.get("/hello") {
     request, response, next in
 
     try response.status(.OK).send("Hello there!").end()
 
 }
+
+
+// MARK: - customKeyConfig
+
+// Custom rate limit configuration for "/hello"
+extension RateLimitConfig {
+    static var customKeyConfig: RateLimitConfig {
+        return RateLimitConfig(window: 10, maxRequests: 10, includeHeaders: true, handler: RateLimitConfig.defaultHandler, keyHandler: RateLimitConfig.customKeyHandler)
+    }
+    
+    public static var customKeyHandler: KeyHandler = {
+        request in
+        
+        return request.queryParameters["client_id"] ?? ""
+    }
+}
+
+// Apply rate limiting with custom configuratioon in "/hello"
+// Veryfy that `router.get("/customKey"…` request queryParameters has a valid client_id
+router.get("/customKey", allowPartialMatch: false, middleware: RateLimit(config: .customKeyConfig, keyStore: MemoryCacheRateLimitKeyStore()))
+router.get("/customKey") {
+    request, response, next in
+    
+    try response.status(.OK).send("Hello there!").end()
+    
+}
+
 
 Kitura.addHTTPServer(onPort: 3000, with: router)
 Kitura.run()

--- a/Sources/KeyHandler.swift
+++ b/Sources/KeyHandler.swift
@@ -1,0 +1,18 @@
+//
+//  KeyHandler.swift
+//  KituraRateLimitExample
+//
+//  Created by Ugo Arangino on 15/01/2017.
+//
+//
+
+import Kitura
+
+/**
+ Converts a `RouterRequest` to a key
+
+ - Parameter routerRequest: The `RouterRequest` object that is used to work with
+                     the incoming request.
+ - returns: A  key for a `RateLimitKeyStore`
+ */
+public typealias KeyHandler = (RouterRequest) -> String

--- a/Sources/RateLimit.swift
+++ b/Sources/RateLimit.swift
@@ -18,6 +18,7 @@ public class RateLimit: RouterMiddleware {
     private var maxRequests: Int
     private var shouldIncludeHeaders: Bool
     private var handler: RouterHandler
+    private var keyHandler: KeyHandler
     
     /// A timer to flush the key-store every <window> seconds
     private var timer: DispatchSourceTimer?
@@ -35,6 +36,7 @@ public class RateLimit: RouterMiddleware {
         self.maxRequests = config.maxRequests
         self.shouldIncludeHeaders = config.includeHeaders
         self.handler = config.handler
+        self.keyHandler = config.keyHandler
         
         startFlushTimer()
     
@@ -53,7 +55,7 @@ public class RateLimit: RouterMiddleware {
     
     public func handle(request: RouterRequest, response: RouterResponse, next: @escaping () -> Void) throws {
         
-        if let currentHits = keyStore.increment(key: request.remoteAddress) {
+        if let currentHits = keyStore.increment(key: keyHandler(request)) {
             
             if shouldIncludeHeaders {
                 

--- a/Sources/RateLimitConfiguration.swift
+++ b/Sources/RateLimitConfiguration.swift
@@ -10,7 +10,7 @@ import Foundation
 import Kitura
 import SwiftyJSON
 
-public typealias KeyHandler = (RouterRequest) -> String
+
 
 public struct RateLimitConfig {
     


### PR DESCRIPTION
This adds a `KeyHandler` to `RateLimitConfig`

The `KeyHandler` takes a `RouterRequest ` and returns a `String` for the `keyStore`.
This extends Kitura-RateLimit so that it is not bound to the *IP address* and can use e.g. the *ClientID* from a *REST* application.